### PR TITLE
Add Claude PR Assistant GitHub Action

### DIFF
--- a/.claude/commands/update-journal.md
+++ b/.claude/commands/update-journal.md
@@ -1,0 +1,5 @@
+- update journal from RSS
+  - https://sizu.me/nitaking/rss から最新の記事を取得
+  - content/docs/journal.mdx を更新
+  - 記事は日付順（新しい順）に整理
+  - 各記事のタイトル、日付、サマリーを含める

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,9 @@
       "WebFetch(domain:*)",
       "WebFetch(domain:zenn.dev)",
       "WebFetch(domain:icemenubar.app)",
-      "WebFetch(domain:www.figma.com)"
+      "WebFetch(domain:www.figma.com)",
+      "WebFetch(domain:chatgpt.com)",
+      "WebFetch(domain:sizu.me)"
     ],
     "deny": []
   }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,38 @@
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude-code-action:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude PR Action
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Or use OAuth token instead:
+          # claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          timeout_minutes: "60"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run Claude PR Action
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Or use OAuth token instead:
-          # claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           timeout_minutes: "60"

--- a/content/docs/journal.mdx
+++ b/content/docs/journal.mdx
@@ -1,6 +1,6 @@
 ---
 title: Journal
-description: しずかなインターネットでの思考と記録
+description:
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/journal.mdx
+++ b/content/docs/journal.mdx
@@ -1,0 +1,46 @@
+---
+title: Journal
+description: しずかなインターネットでの思考と記録
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+<Callout>
+このページは[しずかなインターネット](https://sizu.me/nitaking)のRSSフィードから最近の投稿を集約しています。
+</Callout>
+
+## About
+
+日々の思考、フリーライティング、気づきなどを記録しています。
+
+**RSSフィード**: [https://sizu.me/nitaking/rss](https://sizu.me/nitaking/rss)
+
+## Recent Posts
+
+### 2025年7月
+
+**[フリーライティング：持続可能な人生](https://sizu.me/nitaking/posts/u33xicoo9boc)** _(2025/07/09)_
+フリーライティングを習慣として振り返り、仕事、自己価値、個人的な期待についての深い問いを探求。
+
+### 2025年6月
+
+**[完璧主義を捨てる](https://sizu.me/nitaking/posts/vf4i14su1nwz)** _(2025/06/23)_
+朝のフリーライティングのテクニックについて。
+
+**[夢](https://sizu.me/nitaking/posts/sfmbkcrdix2e)** _(2025/06/09)_
+
+### 2025年5月
+
+**[「問いながら動く」](https://sizu.me/nitaking/posts/h93dto2m4fwb)** _(2025/05/06)_
+
+### 2025年4月
+
+**[横濱舶来亭のカレーが美味い](https://sizu.me/nitaking/posts/3tdvzvz80nv2)** _(2025/04/27)_
+
+## Archives
+
+過去の投稿は[しずかなインターネット](https://sizu.me/nitaking)で閲覧できます。
+
+import { AIEditedFooter } from '@/components/ai-edited-footer';
+
+<AIEditedFooter />

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -29,6 +29,7 @@
     "---💭 Thoughts---",
     "digital-garden-philosophy",
     "deep-research-collection",
+    "journal",
     "---📋 Templates---",
     "adr-architecture-decision-records",
     "postmortem",


### PR DESCRIPTION
  ## Summary
  - Claude PR Assistant GitHub Actionを追加
  - PR/Issueで@claudeメンションに反応する自動化ワークフローを実装

  ## Test plan
  - [ ] GitHub ActionsでClaude PR Assistantが正しく設定されているか確認
  - [ ] @claudeメンションで適切にトリガーされるか確認
  - [ ] 必要な権限が正しく設定されているか確認

  🤖 Generated with [Claude Code](https://claude.ai/code)
  EOF
  