### PR TITLE
Add Moriyama Taido to Photography section

### DIFF
--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -157,6 +157,7 @@ Reflect.appを利用し、一部をこのサイトでPersonal Wikiとして公�
 
 - [Fujifilm](https://reflect.site/g/nitaking/fujifilm/fujifilm)
 - [LOOK - Photography Style Concept](https://reflect.site/g/nitaking/look/51d8074fc2214c01a22e7afa3e74536c)
+- [Moriyama Taido](https://reflect.site/g/nitaking/moriyama-taido/43bf43d7ce0f42c590e50f9edea9be73)
 - [Photography Resources](https://reflect.site/g/nitaking/photography/photography)
 - [内田ユキオ - Photographer Profile](https://reflect.site/g/nitaking//349794d3629d4b52848586b3c2c21129)
 - [電子シャッターとメカシャッター](https://reflect.site/g/nitaking//10aee491b3cc4c669d129effe7405043)


### PR DESCRIPTION
Add Moriyama Taido (Daido Moriyama photographer) link to the Photography section in alphabetical order as requested.

Closes #6

Generated with [Claude Code](https://claude.ai/code)